### PR TITLE
Parameters need an array of values.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.jhonnymertz</groupId>
     <artifactId>java-wkhtmltopdf-wrapper</artifactId>
-    <version>1.0.0-RELEASE</version>
+    <version>1.0.1-RELEASE</version>
 
     <dependencies>
 

--- a/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/params/Param.java
+++ b/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/params/Param.java
@@ -1,18 +1,25 @@
 package com.github.jhonnymertz.wkhtmltopdf.wrapper.params;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Param {
 
     private String key;
 
-    private String value;
+    // Some commands accept more than one value such as cookies and headers
+    private List<String> values;
 
-    public Param(String key, String value) {
+    public Param(String key, String... valueArray) {
         this.key = key;
-        this.value = value;
+        this.values = new ArrayList<String>();
+        for (String value : valueArray) {
+            values.add(value);
+        }
     }
 
     public Param(String key) {
-        this(key, null);
+        this(key, new String[0]);
     }
 
     public String getKey() {
@@ -23,18 +30,38 @@ public class Param {
         this.key = key;
     }
 
+    // This is kept for backwards compatibility it will
+    // only return the first arg if it exists
+    @Deprecated
     public String getValue() {
-        return value;
+        if (values.size() > 0) {
+            return values.get(0);
+        }
+        return null;
     }
 
+    public List<String> getValues() {
+        return values;
+    }
+
+    @Deprecated
     public void setValue(String value) {
-        this.value = value;
+        if (values.size() == 0) {
+            values.add(value);
+        } else {
+            values.set(0, value);
+        }
     }
 
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder().append(Symbol.separator)
                 .append(Symbol.param).append(key);
-        if (value != null)
+        for (String value : values)
             sb.append(Symbol.separator).append(value);
         return sb.toString();
     }

--- a/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/params/Params.java
+++ b/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/params/Params.java
@@ -27,16 +27,17 @@ public class Params {
         for (Param p : params) {
             commandLine.add(p.getKey());
 
-            String value = p.getValue();
-
-            if (value != null) {
-                commandLine.add(p.getValue());
+            for (String value : p.getValues()) {
+                if (value != null) {
+                    commandLine.add(value);
+                }
             }
         }
 
         return commandLine;
     }
 
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         for (Param param : params) {


### PR DESCRIPTION
`--cookie <name> <value>` and `--custom-header <name> <value>` both require two arguments after the key.

I changed Param to have an array of values but left the constructors and old getters/setters to not break backwards compatibility.