### PR TITLE
Bug side effect when multiple calls

### DIFF
--- a/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/Pdf.java
+++ b/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/Pdf.java
@@ -138,10 +138,11 @@ public class Pdf {
                 File temp = File.createTempFile("java-wkhtmltopdf-wrapper" + UUID.randomUUID().toString(), ".html");
                 FileUtils.writeStringToFile(temp, page.getSource(), "UTF-8");
 
-                page.setSource(temp.getAbsolutePath());
+                commandLine.add(temp.getAbsolutePath());
             }
-
-            commandLine.add(page.getSource());
+            else {
+                commandLine.add(page.getSource());
+            }
         }
         commandLine.add(STDINOUT);
         return commandLine.toArray(new String[commandLine.size()]);

--- a/src/test/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/PdfTest.java
+++ b/src/test/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/PdfTest.java
@@ -72,6 +72,27 @@ public class PdfTest {
     }
 
     @Test
+    public void callingGetCommandFollowedByGetPdfShouldNotInfluenceTheOutput() throws Exception {
+        Pdf pdf = new Pdf();
+
+        pdf.addPageFromString("<html><head><meta charset=\"utf-8\"></head><h1>Twice</h1></html>");
+
+        // WHEN
+        pdf.getCommand();//The command side effect cause the second call to getPDF to go wrong
+
+        byte[] pdfBytes = pdf.getPDF();
+
+        PDFParser parser = new PDFParser(new ByteArrayInputStream(pdfBytes));
+
+        // that is a valid PDF (otherwise an IOException occurs)
+        parser.parse();
+        PDFTextStripper pdfTextStripper = new PDFTextStripper();
+        String pdfText = pdfTextStripper.getText(new PDDocument(parser.getDocument()));
+
+        Assert.assertThat("document should contain the string that was originally inserted", pdfText, containsString("Twice"));
+    }
+
+    @Test
     public void testRemovingGeneratedFile() throws Exception {
         Pdf pdf = new Pdf();
         pdf.addPageFromString("<html><head><meta charset=\"utf-8\"></head><h1>Page 1</h1></html>");

--- a/src/test/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/PdfTest.java
+++ b/src/test/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/PdfTest.java
@@ -2,6 +2,7 @@ package com.github.jhonnymertz.wkhtmltopdf.wrapper;
 
 import com.github.jhonnymertz.wkhtmltopdf.wrapper.configurations.WrapperConfig;
 import com.github.jhonnymertz.wkhtmltopdf.wrapper.params.Param;
+import java.io.IOException;
 import org.apache.pdfbox.pdfparser.PDFParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.util.PDFTextStripper;
@@ -40,12 +41,7 @@ public class PdfTest {
         // WHEN
         byte[] pdfBytes = pdf.getPDF();
 
-        PDFParser parser = new PDFParser(new ByteArrayInputStream(pdfBytes));
-
-        // that is a valid PDF (otherwise an IOException occurs)
-        parser.parse();
-        PDFTextStripper pdfTextStripper = new PDFTextStripper();
-        String pdfText = pdfTextStripper.getText(new PDDocument(parser.getDocument()));
+        String pdfText = getPdfTextFromBytes(pdfBytes);
 
         Assert.assertThat("document should contain the creditorName", pdfText, containsString("Müller"));
     }
@@ -61,12 +57,7 @@ public class PdfTest {
         // WHEN
         byte[] pdfBytes = pdf.getPDF();
 
-        PDFParser parser = new PDFParser(new ByteArrayInputStream(pdfBytes));
-
-        // that is a valid PDF (otherwise an IOException occurs)
-        parser.parse();
-        PDFTextStripper pdfTextStripper = new PDFTextStripper();
-        String pdfText = pdfTextStripper.getText(new PDDocument(parser.getDocument()));
+        String pdfText = getPdfTextFromBytes(pdfBytes);
 
         Assert.assertThat("document should contain the fourth page name", pdfText, containsString("Page 4"));
     }
@@ -78,16 +69,11 @@ public class PdfTest {
         pdf.addPageFromString("<html><head><meta charset=\"utf-8\"></head><h1>Twice</h1></html>");
 
         // WHEN
-        pdf.getCommand();//The command side effect cause the second call to getPDF to go wrong
+        pdf.getCommand();
+        //Followed by
+        byte[] pdfBytes = pdf.getPDF();//Causes the page fromString's content to have become the file path
 
-        byte[] pdfBytes = pdf.getPDF();
-
-        PDFParser parser = new PDFParser(new ByteArrayInputStream(pdfBytes));
-
-        // that is a valid PDF (otherwise an IOException occurs)
-        parser.parse();
-        PDFTextStripper pdfTextStripper = new PDFTextStripper();
-        String pdfText = pdfTextStripper.getText(new PDDocument(parser.getDocument()));
+        String pdfText = getPdfTextFromBytes(pdfBytes);
 
         Assert.assertThat("document should contain the string that was originally inserted", pdfText, containsString("Twice"));
     }
@@ -102,5 +88,14 @@ public class PdfTest {
 
         File savedPdf = pdf.saveAs("output.pdf");
         Assert.assertTrue(savedPdf.delete());
+    }
+
+    private String getPdfTextFromBytes(byte[] pdfBytes) throws IOException {
+        PDFParser parser = new PDFParser(new ByteArrayInputStream(pdfBytes));
+
+        // that is a valid PDF (otherwise an IOException occurs)
+        parser.parse();
+        PDFTextStripper pdfTextStripper = new PDFTextStripper();
+        return pdfTextStripper.getText(new PDDocument(parser.getDocument()));
     }
 }


### PR DESCRIPTION
When calling multiple commands in sequence a side effect within the code cause weird output.

E.g.
```java
pdf.getCommand();
//Followed by
byte[] pdfBytes = pdf.getPDF();//Causes the page from strings content to have become the file path
```

Though this sequence of methode call's is unlikely, it's still possible (I did it) and the resulting situation is highly confusing. 

Please let me know if the proposed test and fix are satisfactory.