### PR TITLE
Pass input stream on error

### DIFF
--- a/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/PDFExportException.java
+++ b/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/PDFExportException.java
@@ -1,0 +1,46 @@
+package com.github.jhonnymertz.wkhtmltopdf.wrapper;
+
+/**
+ * PDFExportError.
+ *
+ * @author evgeni.gordeev
+ * @version 1.1.3
+ */
+public class PDFExportException extends RuntimeException {
+
+    private String command;
+
+    private int exitStatus;
+
+    private byte[] out;
+
+    private byte[] err;
+
+    public PDFExportException(String command, int exitStatus, byte[] err, byte[] out) {
+        this.command = command;
+        this.exitStatus = exitStatus;
+        this.err = err;
+        this.out = out;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public int getExitStatus() {
+        return exitStatus;
+    }
+
+    public byte[] getOut() {
+        return out;
+    }
+
+    public byte[] getErr() {
+        return err;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Process (" + this.command + ") exited with status code " + this.exitStatus + ":\n" + new String(err);
+    }
+}

--- a/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/Pdf.java
+++ b/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/Pdf.java
@@ -42,6 +42,8 @@ public class Pdf {
 
     private boolean hasToc = false;
 
+    private int timeout = 10;
+
     public Pdf() {
         this(new WrapperConfig());
     }
@@ -95,6 +97,10 @@ public class Pdf {
 
     public void addTocParam(Param param, Param... params) {
         this.tocParams.add(param, params);
+    }
+
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
     }
 
     public File saveAs(String path) throws IOException, InterruptedException {
@@ -175,7 +181,7 @@ public class Pdf {
 
     private byte[] getFuture(Future<byte[]> future) {
         try {
-            return future.get(10, TimeUnit.SECONDS);
+            return future.get(this.timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
We experienced a lot of sporadic `Exit with code 1 due to network error: ProtocolUnknownError`. even if wkhtmltopdf exits with 1 status, it provides a valid pdf. 