### PR TITLE
getCommandAsArray() handles whitespaces properly

### DIFF
--- a/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/Pdf.java
+++ b/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/Pdf.java
@@ -126,7 +126,7 @@ public class Pdf {
         try {
             String command = getCommand();
             logger.debug("Generating pdf with: {}", command);
-            Process process = Runtime.getRuntime().exec(command);
+            Process process = Runtime.getRuntime().exec(getCommandAsArray());
 
             Future<byte[]> inputStreamToByteArray = executor.submit(streamToByteArrayTask(process.getInputStream()));
             Future<byte[]> outputStreamToByteArray = executor.submit(streamToByteArrayTask(process.getErrorStream()));


### PR DESCRIPTION
Fixes #44 