### PR TITLE
Fix for issue where wkhtmltopdf returns 1 for cases where the PDF is …

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ pdf.addPageFromUrl("http://www.google.com");
 pdf.saveAs("output.pdf");
 ```
 
+wkhtmltopdf exit codes
+------------
+wkhtmltopdf may return non-zero exit codes to denote warnings, you can now set the Pdf 
+object to allow this:
+```
+
+Pdf pdf = new Pdf(wc);
+pdf.addPageFromUrl("http://www.google.com");
+
+pdf.setAllowMissingAssets();
+// or:  
+pdf.setSuccessValues(Arrays.asList(0, 1));
+
+pdf.saveAs("output.pdf");
+```
+
+
+
 License
 ------------
 This project is available under MIT Licence.


### PR DESCRIPTION
I believe that this will enable a workaround for issue #42   -  the default behavior should remain the same but allow library users to choose to workaround the fact that wkhtmltopdf returns 1 in cases where the output is ok.   There are probably some other more advanced workarounds such as capturing and examining the wkhtmltopdf error output, but those are going to be a pain compared to just checking that the output looks reasonable.

Note: My use case is creating PDFs from a templated page, so I can test that the output is ok and then rely on that really only changing if there is a template update.  Others may want/need to look into the more detailed check of wkhtmltopdf's error output to ensure that they only allow the missing assets.

Since the unit/integration tests aren't extensive, I didn't include any although I did add a quick spock test to my own dependent project.