### PR TITLE
change where to where.exe when find executable

### DIFF
--- a/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/configurations/WrapperConfig.java
+++ b/src/main/java/com/github/jhonnymertz/wkhtmltopdf/wrapper/configurations/WrapperConfig.java
@@ -67,7 +67,7 @@ public class WrapperConfig {
         try {
             String osname = System.getProperty("os.name").toLowerCase();
 
-            String cmd = osname.contains("windows") ? "where wkhtmltopdf" : "which wkhtmltopdf";
+            String cmd = osname.contains("windows") ? "where.exe wkhtmltopdf" : "which wkhtmltopdf";
 
             Process p = Runtime.getRuntime().exec(cmd);
             p.waitFor();


### PR DESCRIPTION
executing where in windows 10 causing the executable always not found